### PR TITLE
fix: dual `esm` / `cjs` release support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ node_modules
 dist/cli.*
 dist/*.d.ts
 dist/*.*
+dist/esm
+dist/cjs
 !dist/*action*
 
 # Rest pulled from https://github.com/github/gitignore/blob/master/Node.gitignore

--- a/__tests__/pkg/cjs/.gitignore
+++ b/__tests__/pkg/cjs/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/__tests__/pkg/cjs/index.js
+++ b/__tests__/pkg/cjs/index.js
@@ -1,0 +1,3 @@
+const hashlock = require('hashlock')
+
+console.log('hashlock:', hashlock)

--- a/__tests__/pkg/cjs/package.json
+++ b/__tests__/pkg/cjs/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-cjs",
+  "main": "index.js",
+  "dependencies": {
+    "hashlock": "file:../../../"
+  }
+}

--- a/__tests__/pkg/cjs/pnpm-lock.yaml
+++ b/__tests__/pkg/cjs/pnpm-lock.yaml
@@ -1,0 +1,19 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  hashlock:
+    specifier: file:../../../
+    version: file:../../..
+
+packages:
+
+  file:../../..:
+    resolution: {directory: ../../.., type: directory}
+    name: hashlock
+    engines: {node: '>=20'}
+    hasBin: true
+    dev: false

--- a/__tests__/pkg/esm/.gitignore
+++ b/__tests__/pkg/esm/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/__tests__/pkg/esm/index.mjs
+++ b/__tests__/pkg/esm/index.mjs
@@ -1,0 +1,3 @@
+import hashlock from 'hashlock'
+
+console.log('hashlock:', hashlock)

--- a/__tests__/pkg/esm/package.json
+++ b/__tests__/pkg/esm/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "test-esm",
+  "type": "module",
+  "main": "index.mjs",
+  "module": "index.mjs",
+  "scripts": {
+    "test": "hashlock check ."
+  },
+  "dependencies": {
+    "hashlock": "file:../../../"
+  }
+}

--- a/__tests__/pkg/esm/pnpm-lock.yaml
+++ b/__tests__/pkg/esm/pnpm-lock.yaml
@@ -1,0 +1,19 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  hashlock:
+    specifier: file:../../../
+    version: file:../../..
+
+packages:
+
+  file:../../..:
+    resolution: {directory: ../../.., type: directory}
+    name: hashlock
+    engines: {node: '>=20'}
+    hasBin: true
+    dev: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hashlock",
-  "version": "1.0.0-rc5",
+  "version": "1.0.0-rc6",
   "description": "Verify hash files (like something.sha256)",
   "keywords": [
     "actions",
@@ -25,27 +25,32 @@
   },
   "exports": {
     "./generator": {
-      "require": "./dist/generator.js",
-      "import": "./dist/generator.mjs",
+      "require": "./dist/cjs/generator.js",
+      "import": "./dist/esm/generator.mjs",
       "types": "./dist/generator.d.ts",
-      "default": "./dist/generator.js"
+      "default": "./dist/esm/generator.mjs"
     },
     "./model": {
-      "require": "./dist/model.js",
-      "import": "./dist/model.mjs",
+      "require": "./dist/cjs/model.js",
+      "import": "./dist/esm/model.mjs",
       "types": "./dist/model.d.ts",
-      "default": "./dist/model.js"
+      "default": "./dist/esm/model.mjs"
     },
     ".": {
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.mjs",
       "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+      "default": "./dist/esm/index.mjs"
     }
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "hashlock": "./dist/cli.mjs"
+  },
   "files": [
+    "dist/cjs/*.js",
+    "dist/esm/*.*",
     "dist/*.js",
     "dist/*.cjs",
     "dist/*.mjs",

--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -16,12 +16,14 @@ import * as esbuild from 'esbuild'
 
 const buildSettings = {
   ...common,
-  format: 'esm',
-  entryPoints: ['src/entry.ts'],
-  outfile: 'dist/cli.js'
+  entryPoints: ['src/entry.ts']
 }
 
 export default async function buildCli() {
-  console.info("- Building 'hashlock' (CLI)...")
-  await esbuild.build(buildSettings)
+  console.info("- Building 'hashlock' (CLI, esm)...")
+  await esbuild.build({
+    ...buildSettings,
+    format: 'esm',
+    outfile: 'dist/cli.mjs'
+  })
 }

--- a/scripts/build-lib.mjs
+++ b/scripts/build-lib.mjs
@@ -29,13 +29,16 @@ const buildSettings = {
 const buildSettingsCjs = {
   ...buildSettings,
   format: 'cjs',
-  outdir: 'dist'
+  outdir: 'dist/cjs'
 }
 
 const buildSettingsEsm = {
   ...buildSettings,
   format: 'esm',
-  outdir: 'dist'
+  outdir: 'dist/esm',
+  outExtension: {
+    '.js': '.mjs'
+  }
 }
 
 export default async function buildLib() {


### PR DESCRIPTION
- fix: build esm and cjs dist roots
- fix: extensions for mjs use
- fix: use of binary js entry
- test: add smoke tests for package use