### PR TITLE
chore: version bump → `1.0.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hashlock",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Verify hash files (like something.sha256)",
   "keywords": [
     "actions",


### PR DESCRIPTION
Runs the release flow with a version bump, now that provenance and other mechanisms are working well 👍 